### PR TITLE
Lab09: CarSeller: Added scanner closing

### DIFF
--- a/Lab_09/CarSeller/src/it/unisa/carseller/CarSeller.java
+++ b/Lab_09/CarSeller/src/it/unisa/carseller/CarSeller.java
@@ -27,6 +27,7 @@ public class CarSeller {
                 ex.printStackTrace();
             }
         }
+        input.close();
     }
 
     public void writeUserDataToFile(File file, boolean overwrite) throws FileNotFoundException, FileAlreadyExistsException {

--- a/Lab_09/CarSeller/task-info.yaml
+++ b/Lab_09/CarSeller/task-info.yaml
@@ -10,30 +10,30 @@ files:
     visible: true
     placeholders:
       - offset: 329
-        length: 688
+        length: 711
         placeholder_text: /* TODO */
-      - offset: 1090
+      - offset: 1113
         length: 57
         placeholder_text: /* TODO */
-      - offset: 1158
+      - offset: 1181
         length: 495
         placeholder_text: /* TODO */
-      - offset: 1665
+      - offset: 1688
         length: 390
         placeholder_text: /* TODO */
-      - offset: 2199
+      - offset: 2222
         length: 141
         placeholder_text: /* TODO */
-      - offset: 2430
+      - offset: 2453
         length: 142
         placeholder_text: /* TODO */
-      - offset: 2717
+      - offset: 2740
         length: 259
         placeholder_text: /* TODO */
-      - offset: 3087
+      - offset: 3110
         length: 350
         placeholder_text: /* TODO */
-      - offset: 3582
+      - offset: 3605
         length: 450
         placeholder_text: /* TODO */
   - name: test/it/unisa/carseller/CarSellerTest.java


### PR DESCRIPTION
Closing the scanner in `readUserDataFromFile(File file)` of CarSeller Class avoids conflicts with other methods that use or delete _"test/testData.txt"_. 
Now in `writeUserDataToFile` it's possible to directly delete the file without the creation of a temp file (no exceptions will be thrown).

Just as Example:
 
```Java
public void writeUserDataToFile(File file, boolean overwrite) /* TODO */throws FileNotFoundException, FileAlreadyExistsException {
        /* TODO */
        if (!overwrite && file.exists()) {
            throw new FileAlreadyExistsException("File già esiste - scelto di non sovrascrivere. ");
        } else {
            try{
                Files.deleteIfExists(file.toPath());
            } catch (IOException e ){
                e.printStackTrace();
                System.err.println("Errore Cancellazione File");
            }
            try( PrintWriter stampaFile = new PrintWriter(new FileWriter(file, false)) ){
                for (Car c : cars) {
                    stampaFile.println(c.getBrand());
                    stampaFile.println(c.getModel());
                    stampaFile.println(c.getManufacturingYear());
                    stampaFile.println(c.getPrice());
                }
                if(stampaFile.checkError()) System.out.println("ERRORE PRINTWRITER");
                stampaFile.close();
            } catch (IOException e){
                System.err.println(e.getMessage());
            }
        }
    }
```

